### PR TITLE
Update eip-5564.md

### DIFF
--- a/eip-5564.md
+++ b/eip-5564.md
@@ -107,7 +107,7 @@ interface IERC5564Messenger {
     bytes32 stealthRecipientandViewTag,
     bytes32 metadata
   ) external;
-  }
+}
   
   /// @dev Emitted when sending something to a stealth address.
   event Announcement (

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -55,7 +55,7 @@ interface IERC5564Registry {
   /// @dev The pubkey is passed as `bytes memory` to support pubkeys of any format and size.
   /// @dev Generator contracts SHOULD be written to support a single public key, or two public keys:
   /// one viewing key and one spending key. This can be inferred from the length of the key material.
-  function registerKeysOnBehalf(
+  function registerKeysOnBehalf (
     address registrant,
     uint8 v,
     bytes32 r,
@@ -93,7 +93,7 @@ interface IERC5564Generator {
 
 /// @notice Interface for sending tokens to a stealth address.
 interface IERC5564Messenger {
-  /// @dev Emitted when sending something to a stealth address.
+  /// @dev Called when sending something to a stealth address.
   /// @dev ephemeralPubKey represents the ephemeral public key of the sender.
   /// @dev StealthRecipientandViewTag contains the stealth address (20 bytes) and the view tag (12 bytes).
   /// @dev Metadata is an arbitrary field that the sender can use however they like, but the below
@@ -102,7 +102,20 @@ interface IERC5564Messenger {
   ///     bytes, and the amount being sent as the following 32 bytes.
   ///   - When sending ERC-721 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the token ID being sent as the following 32 bytes.
-  event Announcement(
+  function emitAnnoucement (
+    bytes memory ephemeralPubKey,
+    bytes32 stealthRecipientandViewTag,
+    bytes32 metadata
+  ) external {
+    emit Annoucement (
+      bytes ephemeralPubKey,
+      bytes32 stealthRecipientandViewTag,
+      bytes32 metadata
+    );
+  }
+  
+  /// @dev Emitted when sending something to a stealth address.
+  event Announcement (
     bytes ephemeralPubKey,
     bytes32 indexed stealthRecipientandViewTag,
     bytes32 metadata
@@ -183,7 +196,10 @@ Usually, the recipient of a stealth address transaction has to perform the follo
 - 2x HASH,
 - 1x ecADD,
 
-The [view tags](https://github.com/monero-project/research-lab/issues/73) approach was introduced in order to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 12 bytes length was is based on the freely available space in the first log of the `Announcement` Event. With 12 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ can be determined as follows: $1/(256^{12})$. This means that users can almost certainly skip the above three operations for any announcents that to do not involve them.
+The [view tags](https://github.com/monero-project/research-lab/issues/73) approach is introduced to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 12 bytes length was is based on the freely available space in the first log of the `Announcement` Event. With 12 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ can be determined as follows: $1/(256^{12})$. This means that users can almost certainly skip the above three operations for any announcents that to do not involve them.
+
+### Elliptic Curve 
+
 
 ## Rationale
 This EIP emerged from the need of having privacy-preserving ways to transfer ownership without revealing the recipient's identity. Tokens can reveal sensitive private information about the owner. While users might want to donate money to a specific organisation/country but they might not want to reveal personal account-related information at the same time. The standardization of stealth address generation represents a significant effort for privacy: privacy-preserving solutions require standards to gain adoption, therefore it is critical to focus on generalizable ways of implementing related solutions.

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -102,16 +102,11 @@ interface IERC5564Messenger {
   ///     bytes, and the amount being sent as the following 32 bytes.
   ///   - When sending ERC-721 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the token ID being sent as the following 32 bytes.
-  function emitAnnoucement (
+  function emitAnnouncement (
     bytes memory ephemeralPubKey,
     bytes32 stealthRecipientandViewTag,
     bytes32 metadata
-  ) external {
-    emit Annoucement (
-      bytes ephemeralPubKey,
-      bytes32 stealthRecipientandViewTag,
-      bytes32 metadata
-    );
+  ) external;
   }
   
   /// @dev Emitted when sending something to a stealth address.

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -107,7 +107,6 @@ interface IERC5564Messenger {
     bytes32 stealthRecipientandViewTag,
     bytes32 metadata
   ) external;
-}
   
   /// @dev Emitted when sending something to a stealth address.
   event Announcement (


### PR DESCRIPTION
Hi Matt and Ben!

I added a function to the messeger contract.
Are we on the same page, that the sender "routes" the transaction trough the messeger contract?

I though about the following:
We could have fallback function that parses the info from the call and executes the transaction just like a proxy. This would allow the protocol to be used for every interaction with a stealth address. F.e. you could approve tokens to a stealth address and emit that through the messenger contract. The metadata field in the Announcement has space to indicate that the interactions was an "approval" of token "x". 
Furthermore, we do not need to think about possible new token standards since it's very agnostic.