### PR TITLE
update solidity interfaces and algorithm

### DIFF
--- a/eip-5564.md
+++ b/eip-5564.md
@@ -71,7 +71,8 @@ interface IERC5564Registry {
 interface IERC5564Generator {
   /// @notice Given a `registrant`, returns all relevant data to compute a stealth address.
   /// @dev MUST return all zeroes if the registrant has not registered keys for this generator.
-  /// @dev The returned `viewTag` MUST be the keccak256 hash of the `sharedSecret`.
+  /// @dev The returned `viewTag` MUST be the hash of the `sharedSecret`. THe hashing function used
+  /// is specified by the generator.
   /// @dev `ephemeralPubKey` represents the ephemeral public key used by the sender.
   /// @dev Intended to be used off-chain only to prevent exposing secrets on-chain.
   /// @dev Consider running this against a local node, or using an off-chain library with the same
@@ -107,7 +108,7 @@ interface IERC5564Generator {
 /// @notice Interface for announcing that something was sent to a stealth address.
 interface IERC5564Messenger {
   /// @dev Emitted when sending something to a stealth address.
-  /// @dev See `emitAnnouncement` for documentation on the parameters.
+  /// @dev See `announce` for documentation on the parameters.
   event Announcement(
     bytes ephemeralPubKey, bytes32 indexed stealthRecipientAndViewTag, bytes32 metadata
   );
@@ -122,7 +123,7 @@ interface IERC5564Messenger {
   ///     bytes, and the amount being sent as the following 32 bytes.
   ///   - When sending ERC-721 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the token ID being sent as the following 32 bytes.
-  function emitAnnouncement(
+  function announce(
     bytes memory ephemeralPubKey,
     bytes32 stealthRecipientAndViewTag,
     bytes32 metadata
@@ -212,29 +213,29 @@ Other encryption schemes such as post-quantum encryption with Kyber may need to 
 - This function performs the following computations:
   - A shared secret $s$ is computed as $s = p_{ephemeral} \cdot P_{view}$.
   - The secret is hashed $s_{h} = h(s)$.
-  - The viewTag is extracted by taking the most significant 12 bytes $s_{h}[0:12]$,
-  - Multiplying the hashed secret with the generator point $S = s_{h} \cdot G$.
+  - The view tag $v$ is extracted by taking the most significant 12 bytes $s_{h}[0:12]$,
+  - Multiplying the shared secret with the generator point $S = s \cdot G$.
   - The recipient's stealth public key is computed as $P_{stealth} = P_{spend} + S$.
-  - The recipient's stealth address is computed as $pubkeyToAddress(P_{stealth})$.
+  - The recipient's stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.
 
 Sending funds now works as follows:
 - Sender uses the contract of their choice to send something to $a_{stealth}$, and provides $P_{ephemeral}$ and any other metadata to the send method.
-- The contract calls `IERC5564Messenger.announce` with $a_{stealth} + viewTag$, $P_{ephemeral}$, and any metadata.
+- The contract calls `IERC5564Messenger.announce` with $a_{stealth}$, $v$, $P_{ephemeral}$, and any metadata.
 
 To scan for funds, a recipient must retrieve all logs from the `IERC5564Messenger` contract.
-They then check if they can compute the stealth address $P_{stealth}$ that was emitted as stealth address $a_{stealth}$in the `Announcement`. If successful, the recipient can generate  $p_{stealth}$, representing the private key that can eventually access $P_{stealth}$.
+They then check if they can compute the stealth address $P_{stealth}$ that was emitted as stealth address $a_{stealth}$ in the `Announcement`. If successful, the recipient can generate  $p_{stealth}$, representing the private key that can eventually access $P_{stealth}$.
 
 The parsing process can be presented as follows:
 - Recipient has private keys $p_{view}$ and $p_{spend}$.
-- Recipient parses all Announcements $AN$ performs the following operations:
+- Recipient parses all Announcements $a_i$ performs the following operations:
 - This function performs the following computations:
-  - Computing the shared secret $s$ is computed as $s = AN \cdot p_{view}$.
-  - Hashing the secret, $s_{h} = h(s)$.
-  - Comparing the most significant 12 bytes of the resulting hash with the view tag emitted in the event and continue if matching
-  - Multiplying the hashed secret with the generator point $S = s_{h} \cdot G$.
-  - Compute stealth public key  as $P_{stealth} = P_{spend} + S$.
-  - The recipient's address is computed as $stealthAddress = pubkeyToAddress(P_{stealth})$.
-  - Compare $stealthAddress$ with the stealth address logged the emitted event.
+  - Computing the shared secret $s$ is computed as $s = a_{i, P_{ephemeral}} \cdot p_{view}$.
+  - Hashing the shared secret, $s_{h} = h(s)$.
+  - Comparing the most significant 12 bytes of the resulting hash with the view tag emitted in the event and continue if they match.
+  - Multiplying the shared secret with the generator point $S = s \cdot G$.
+  - Compute stealth public key as $P_{stealth} = P_{spend} + S$.
+  - The recipient's address is computed as $a_{stealth} = \textrm{pubkeyToAddress(P_{stealth})}$.
+  - Compare $a_{stealth}$ with the stealth address logged the emitted `Announcement` event.
 
 ### Parsing considerations
 Usually, the recipient of a stealth address transaction has to perform the following operations to check weather he was the recipient of a certain transaction:

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -22,125 +22,184 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 The follow contracts are part of this specification:
 - `IERC5564Registry` stores the stealth public keys for users. This MUST be a singleton contract, with one instance per chain.
-- `IERC5565Generator` contracts are used to compute stealth addresses for a user based on a given curve. There can be many of these per chain, and for a given curve there SHOULD be one implementation per chain.
+- `IERC5565Generator` contracts are used to compute stealth addresses for a user based on a given curve. There can be many of these per chain, and for a given curve there SHOULD be one implementation per chain. Generator contracts are intended to primarily serve as reference implementations for off-chain libraries, as calling a method over HTTPS to generate a stealth address may compromise the user's privacy depending on who runs the node.
 - `IERC5564Messenger` emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain.
 
 The interface for each is specified as follows:
 
-```solidity
-// SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+### `IERC5564Registry`
 
-/// @notice Registry mapping an address to its stealth key information.
+```solidity
+/// @notice Registry to map an address to its stealth key information.
 interface IERC5564Registry {
   /// @notice Returns the stealth public keys for the given `registrant` to compute a stealth
   /// address accessible only to that `registrant` using the provided `generator` contract.
   /// @dev MUST return zero if a registrant has not registered keys for the given generator.
-  /// @dev The pubkeys are returned as `bytes memory` to support pubkeys of any  format and size.
-  /// @dev Generator contracts SHOULD be written to support a single public key, or two public keys:
-  /// one viewing key and one spending key. This can be inferred from the length of the key material.
   function stealthKeys(address registrant, address generator)
     external
     view
-    returns (bytes memory pubKey);
+    returns (bytes memory spendingPubKey, bytes memory viewingPubKey);
 
   /// @notice Sets the caller's stealth public keys for the `generator` contract.
-  /// @dev The pubkey is passed as `bytes memory` to support pubkeys of any format and size.
-  /// @dev Generator contracts SHOULD be written to support a single public key, or two public keys:
-  /// one viewing key and one spending key. This can be inferred from the length of the key material.
-  function registerKeys(address generator, bytes memory pubKey) external;
+  function registerKeys(address generator, bytes memory spendingPubKey, bytes memory viewingPubKey)
+    external;
 
   /// @notice Sets the `registrant`s stealth public keys for the `generator` contract using their
-  /// signature, given by `v`, `r`, and `s`.
-  /// @dev The pubkey is passed as `bytes memory` to support pubkeys of any format and size.
-  /// @dev Generator contracts SHOULD be written to support a single public key, or two public keys:
-  /// one viewing key and one spending key. This can be inferred from the length of the key material.
+  /// `signature`.
+  /// @dev MUST support both EOA signatures and EIP-1271 signatures.
   function registerKeysOnBehalf(
     address registrant,
-    uint8 v,
-    bytes32 r,
-    bytes32 s,
     address generator,
-    bytes memory pubKey
+    bytes memory signature,
+    bytes memory spendingPubKey,
+    bytes memory viewingPubKey
   ) external;
 
-  /// @dev Event emitted when a registrant updates their registered stealth keys.
-  event StealthKeyChanged(address indexed registrant, address indexed generator, bytes pubKey);
+  /// @dev Emitted when a registrant updates their registered stealth keys.
+  event StealthKeyChanged(
+    address indexed registrant, address indexed generator, bytes spendingPubKey, bytes viewingPubKey
+  );
 }
+```
+### `IERC5564Generator`
 
-/// @notice Interface for generating stealth addresses for keys on a given curve.
-/// @dev The Generator contract SHOULD have a method called decodeKeys that returns the recipient's
-/// public keys as the correct types. This is not included below since the return parameters may
-/// differ for each Generator.
+```solidity
+/// @notice Interface for generating stealth addresses for keys from a given stealth address scheme.
+/// @dev The Generator contract MUST have a method called `stealthKeys` that returns the recipient's
+/// public keys as the correct types. The return types will vary for each generator, so a sample
+/// is shown below.
 interface IERC5564Generator {
   /// @notice Given a `registrant`, returns all relevant data to compute a stealth address.
   /// @dev MUST return all zeroes if the registrant has not registered keys for this generator.
+  /// @dev The returned `viewTag` MUST be the keccak256 hash of the `sharedSecret`.
+  /// @dev `ephemeralPubKey` represents the ephemeral public key used by the sender.
   /// @dev Intended to be used off-chain only to prevent exposing secrets on-chain.
   /// @dev Consider running this against a local node, or using an off-chain library with the same
   /// logic, instead of via an `eth_call` to a public RPC provider to avoid leaking secrets.
-  /// @dev Consult the generator's documentation for details on how to format this parameter.
   function generateStealthAddress(address registrant)
     external
     view
     returns (
       address stealthAddress,
-      uint256 sharedSecret,
-      bytes32 sharedSecretHash,
-      bytes32 viewTag,
-      bytes memory ephemeralPubKey
+      bytes memory ephemeralPubKey,
+      bytes memory sharedSecret,
+      bytes32 viewTag
+    );
+
+  /// @notice Returns the stealth public keys for the given `registrant`, in the types that best
+  /// represent the curve.
+  /// @dev The below is an example for the secp256k1 curve.
+  function stealthKeys(address registrant)
+    external
+    view
+    returns (
+      uint256 spendingPubKeyX,
+      uint256 spendingPubKeyY,
+      uint256 viewingPubKeyX,
+      uint256 viewingPubKeyY
     );
 }
+```
 
-/// @notice Interface for sending tokens to a stealth address.
+### `IERC5564Messenger`
+
+```solidity
+/// @notice Interface for announcing that something was sent to a stealth address.
 interface IERC5564Messenger {
   /// @dev Emitted when sending something to a stealth address.
-  /// @dev ephemeralPubKey represents the ephemeral public key of the sender.
-  /// @dev StealthRecipientandViewTag contains the stealth address (20 bytes) and the view tag (12 bytes).
-  /// @dev Metadata is an arbitrary field that the sender can use however they like, but the below
+  /// @dev See `emitAnnouncement` for documentation on the parameters.
+  event Announcement(
+    bytes ephemeralPubKey, bytes32 indexed stealthRecipientAndViewTag, bytes32 metadata
+  );
+
+  /// @dev Called by integrators to emit an `Announcement` event.
+  /// @dev `ephemeralPubKey` represents the ephemeral public key used by the sender.
+  /// @dev `stealthRecipientAndViewTag` contains the stealth address (20 bytes) and the view tag (12
+  /// bytes).
+  /// @dev `metadata` is an arbitrary field that the sender can use however they like, but the below
   /// guidelines are recommended:
   ///   - When sending ERC-20 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the amount being sent as the following 32 bytes.
   ///   - When sending ERC-721 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the token ID being sent as the following 32 bytes.
-  event Announcement(
-    bytes ephemeralPubKey,
-    bytes32 indexed stealthRecipientandViewTag,
-    bytes32 metadata
-  );
-}
-
-/// @notice Sample implementation for generating stealth addresses for keys on the secp256k1 curve.
-function generateStealthAddress(address registrant, bytes memory ephemeralPrivKey)
-  external
-  view
-  returns (
-    address stealthAddress,
-    uint256 sharedSecret,
-    bytes32 sharedSecretHash,
+  function emitAnnouncement(
     bytes memory ephemeralPubKey,
-    bytes memory viewTag
-  )
-{
-  // Get user's public keys.
-  (bytes memory viewPubKey, bytes memory spendPubKey) =
-    IERC5564Registry(registry).stealthKeys(registrant, address(this));
-
-  // Generate shared secret from sender's private key and recipient's viewing key.
-  sharedSecret = ecMul(ephemeralPrivKey, viewPubKey);
-  sharedSecretHash = keccak256(sharedSecret);
-  
-  // Generate view tag for enabling faster parsing for the recipient
-  viewTag = sharedSecretHash[0:12];
-
-  // Generate a point from the hash of the shared secret
-  sharedSecretPoint = ecMul(sharedSecretHash, G);
-
-  // Generate sender's public key from their ephemeral private key.
-  stealthPubKey = ecAdd(spendPubKey, sharedSecretPoint);
-
-  // Compute stealth address from the steath public key.
-  stealthAddress = pubkeyToAddress(ephemeralPubKey);
+    bytes32 stealthRecipientAndViewTag,
+    bytes32 metadata
+  ) external;
 }
+```
+
+### Sample Generator Implementation
+
+```solidity
+/// @notice Sample IERC5564Generator implementation for the secp256k1 curve.
+contract Secp256k1Generator is IERC5564Generator {
+  /// @notice Address of this chain's registry contract.
+  IERC5564Registry public constant REGISTRY = IERC5564Registry(address(0));
+
+  /// @notice Sample implementation for parsing stealth keys on the secp256k1 curve.
+  function stealthKeys(address registrant)
+    external
+    view
+    returns (
+      uint256 spendingPubKeyX,
+      uint256 spendingPubKeyY,
+      uint256 viewingPubKeyX,
+      uint256 viewingPubKeyY
+    )
+  {
+    // Fetch the raw spending and viewing keys from the registry.
+    (bytes memory spendingPubKey, bytes memory viewingPubKey) =
+      REGISTRY.stealthKeys(registrant, address(this));
+
+    // Parse the keys.
+    assembly {
+      spendingPubKeyX := mload(add(spendingPubKey, 0x20))
+      spendingPubKeyY := mload(add(spendingPubKey, 0x40))
+      viewingPubKeyX := mload(add(viewingPubKey, 0x20))
+      viewingPubKeyY := mload(add(viewingPubKey, 0x40))
+    }
+  }
+
+  /// @notice Sample implementation for generating stealth addresses for the secp256k1 curve.
+  function generateStealthAddress(address registrant, bytes memory ephemeralPrivKey)
+    external
+    view
+    returns (
+      address stealthAddress,
+      bytes memory ephemeralPubKey,
+      bytes memory sharedSecret,
+      bytes32 viewTag
+    )
+  {
+    // Get the ephemeral public key from the private key.
+    ephemeralPubKey = ecMul(ephemeralPrivKey, G);
+
+    // Get user's parsed public keys.
+    (
+      uint256 spendingPubKeyX,
+      uint256 spendingPubKeyY,
+      uint256 viewingPubKeyX,
+      uint256 viewingPubKeyY
+    ) = stealthKeys(registrant, address(this));
+
+    // Generate shared secret from sender's private key and recipient's viewing key.
+    sharedSecret = ecMul(ephemeralPrivKey, viewingPubKeyX, viewingPubKeyY);
+    bytes32 sharedSecretHash = keccak256(sharedSecret);
+
+    // Generate view tag for enabling faster parsing for the recipient
+    viewTag = sharedSecretHash[0:12];
+
+    // Generate a point from the hash of the shared secret
+    bytes memory sharedSecretPoint = ecMul(sharedSecret, G);
+
+    // Generate sender's public key from their ephemeral private key.
+    bytes memory stealthPubKey = ecAdd(spendingPubKeyX, spendingPubKeyY, sharedSecretPoint);
+
+    // Compute stealth address from the stealth public key.
+    stealthAddress = pubkeyToAddress(stealthPubKey);
+  }
 ```
 
 Stealth addresses are computed using the algorithm below, assuming elliptic curves.
@@ -153,7 +212,7 @@ Other encryption schemes such as post-quantum encryption with Kyber may need to 
 - This function performs the following computations:
   - A shared secret $s$ is computed as $s = p_{ephemeral} \cdot P_{view}$.
   - The secret is hashed $s_{h} = h(s)$.
-  - The viewTag is extracted by taking the most significant 12 bytes $s_{h}[0:12]$, 
+  - The viewTag is extracted by taking the most significant 12 bytes $s_{h}[0:12]$,
   - Multiplying the hashed secret with the generator point $S = s_{h} \cdot G$.
   - The recipient's stealth public key is computed as $P_{stealth} = P_{spend} + S$.
   - The recipient's stealth address is computed as $pubkeyToAddress(P_{stealth})$.
@@ -183,10 +242,10 @@ Usually, the recipient of a stealth address transaction has to perform the follo
 - 2x HASH,
 - 1x ecADD,
 
-The [view tags](https://github.com/monero-project/research-lab/issues/73) approach was introduced in order to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 12 bytes length was is based on the freely available space in the first log of the `Announcement` Event. With 12 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ can be determined as follows: $1/(256^{12})$. This means that users can almost certainly skip the above three operations for any announcents that to do not involve them.
+The [view tags](https://github.com/monero-project/research-lab/issues/73) approach is introduced to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 12 bytes length was is based on the freely available space in the first log of the `Announcement` Event. With 12 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ can be determined as follows: $1/(256^{12})$. This means that users can almost certainly skip the above three operations for any announcements that to do not involve them.
 
 ## Rationale
-This EIP emerged from the need of having privacy-preserving ways to transfer ownership without revealing the recipient's identity. Tokens can reveal sensitive private information about the owner. While users might want to donate money to a specific organisation/country but they might not want to reveal personal account-related information at the same time. The standardization of stealth address generation represents a significant effort for privacy: privacy-preserving solutions require standards to gain adoption, therefore it is critical to focus on generalizable ways of implementing related solutions.
+This EIP emerged from the need of having privacy-preserving ways to transfer ownership without revealing the recipient's identity. Tokens can reveal sensitive private information about the owner. While users might want to donate money to a specific organization/country but they might not want to reveal personal account-related information at the same time. The standardization of stealth address generation represents a significant effort for privacy: privacy-preserving solutions require standards to gain adoption, therefore it is critical to focus on generalizable ways of implementing related solutions.
 
 The stealth address extension standardizes a protocol for generating and locating stealth addresses, enabling the transfer of assets without the need for prior interaction with the recipient and allowing recipients to verify the receipt of a transfer without interacting with the blockchain. Importantly, stealth addresses allow the recipient of a token transfer to verify receipt while maintaining their privacy, as only the recipient is able to see that they have been the recipient of the transfer.
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -234,7 +234,7 @@ The parsing process can be presented as follows:
   - Comparing the most significant 12 bytes of the resulting hash with the view tag emitted in the event and continue if they match.
   - Multiplying the shared secret with the generator point $S = s \cdot G$.
   - Compute stealth public key as $P_{stealth} = P_{spend} + S$.
-  - The recipient's address is computed as $a_{stealth} = \textrm{pubkeyToAddress(P_{stealth})}$.
+  - The recipient's address is computed as $a_{stealth} = \textrm{pubkeyToAddress}(P_{stealth})$.
   - Compare $a_{stealth}$ with the stealth address logged the emitted `Announcement` event.
 
 ### Parsing considerations


### PR DESCRIPTION
Updates the Solidity interfaces based on things we've discussed:
- Note that the Generator contract is mainly a reference and you shouldn't use it unless using your own node to call it.
- Spending and viewing public keys are explicitly part of the spec as agreed upon in https://github.com/nerolation/EIP-Stealth-Address-ERC/pull/2#discussion_r1009760585
- The shared secret is directly used to compute the stealth address, as specified in DKSAP section of [this article](https://hackernoon.com/blockchain-privacy-enhancing-technology-series-stealth-address-i-c8a3eb4e4e43)
- Removes the `sharedSecretHash` parameter from `generateStealthAddress`. There is now a discrepancy: the view tag is specified as 32 bytes in the return parameter, but in the `Announcement` event it's spec'd as being 12 bytes to pack with the stealth address. Is the complexity (for e.g. frontends) of packing `stealthRecipientAndViewTag` instead of separating them as two different params worth the small gas savings? I think I lean towards separating them out as distinct parameters and using a 32 byte view tag—the added gas cost will be small and the simpler we can make the spec the more likely it is to gain adoption

And one new thing which I don't think we've discussed:
- Updates `registerKeysOnBehalf` to take the signatures as `bytes` and requires supporting EIP-1271.

This PR does not make significant changes to other parts of the EIP. Planning to review the rest of it later this week