### PR TITLE
separate stealth address and view tag params in Announcement

### DIFF
--- a/eip-5564.md
+++ b/eip-5564.md
@@ -115,16 +115,16 @@ interface IERC5564Generator {
 /// @notice Interface for announcing that something was sent to a stealth address.
 interface IERC5564Messenger {
   /// @dev Emitted when sending something to a stealth address.
-  /// @dev See `announce` for documentation on the parameters.
+  /// @dev See the `announce` method for documentation on the parameters.
   event Announcement(
-    bytes ephemeralPubKey, bytes32 indexed stealthRecipientAndViewTag, bytes32 metadata
+    bytes ephemeralPubKey, address indexed stealthAddress, bytes32 viewTag, bytes32 metadata
   );
 
   /// @dev Called by integrators to emit an `Announcement` event.
-  /// @dev `ephemeralPubKey` represents the ephemeral public key used by the sender.
-  /// @dev `stealthRecipientAndViewTag` contains the stealth address (20 bytes) and the view tag (12
-  /// bytes).
-  /// @dev `metadata` is an arbitrary field that the sender can use however they like, but the below
+  /// @param ephemeralPubKey Ephemeral public key used by the sender.
+  /// @param stealthAddress The computed stealth address for the recipient.
+  /// @param viewTag The hash of the shared secret used to compute the stealth address.
+  /// @param metadata An arbitrary field that the sender can use however they like, but the below
   /// guidelines are recommended:
   ///   - When sending ERC-20 tokens, the metadata SHOULD include the token address as the first 20
   ///     bytes, and the amount being sent as the following 32 bytes.
@@ -132,7 +132,8 @@ interface IERC5564Messenger {
   ///     bytes, and the token ID being sent as the following 32 bytes.
   function announce(
     bytes memory ephemeralPubKey,
-    bytes32 stealthRecipientAndViewTag,
+    address stealthAddress,
+    bytes32 viewTag,
     bytes32 metadata
   ) external;
 }
@@ -208,6 +209,7 @@ contract Secp256k1Generator is IERC5564Generator {
     // Compute stealth address from the stealth public key.
     stealthAddress = pubkeyToAddress(stealthPubKey);
   }
+}
 ```
 
 Stealth addresses are computed using the algorithm below, assuming elliptic curves.


### PR DESCRIPTION
Adds a small amount of gas cost to announcements, but simplifies things for integrators by making it easier to provide and parse the stealth address and view tag data