### PR TITLE
refactor EIP

### DIFF
--- a/eip-5564.md
+++ b/eip-5564.md
@@ -10,7 +10,6 @@ category: ERC
 created: 2022-08-13
 ---
 
-
 ## Abstract
 
 This specification defines a standardized way of creating stealth addresses. This EIP enables senders of transactions/transfers to non-interactively generate private stealth addresses for their recipients that only the recipients can unlock.
@@ -23,197 +22,103 @@ The standardization of non-interactive stealth address generation holds the pote
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-The follow contracts are part of this specification:
+Definitions:
 
-- `IERC5564Registry` stores the stealth public keys for users. This MUST be a singleton contract, with one instance per chain.
+- A "stealth meta-address" is a set of one or two public keys that can be used to compute a stealth address for a given recipient.
+- A "spending key" is a private key that can be used to spend funds sent to a stealth address. A "spending public key" is the corresponding public key.
+- A "viewing key" is a private key that can be used to determine if funds sent to a stealth address belong to the recipient who controls the corresponding spending key. A "viewing public key" is the corresponding public key.
 
-- `IERC5565Generator` contracts are used to compute stealth addresses for a user based on a given curve. There can be many of these per chain, and for a given curve there SHOULD be one implementation per chain. Generator contracts are intended to primarily serve as reference implementations for off-chain libraries, as calling a method over HTTPS to generate a stealth address may compromise the user's privacy depending on who runs the node.
+Different stealth address schemes will have different expected stealth meta-address lengths. A scheme that uses public keys of length `n` bytes MUST define stealth meta-addresses as follows:
 
-- `IERC5564Messenger` emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain.
+- A stealth meta-address of length `n` uses the same stealth meta-address for the spending public key and viewing public key.
+- A stealth meta-address of length `2n` uses the first `n` bytes as the spending public key and the last `n` bytes as the viewing public key.
 
-The interface for each is specified as follows:
-
-### `IERC5564Registry`
+Given a recipient's stealth meta-address, a sender MUST be able generate a stealth address for the recipient by calling a method with the following signature:
 
 ```solidity
-/// @notice Registry to map an address to its stealth key information.
-interface IERC5564Registry {
-  /// @notice Returns the stealth public keys for the given `registrant` to compute a stealth
-  /// address accessible only to that `registrant` using the provided `generator` contract.
-  /// @dev MUST return zero if a registrant has not registered keys for the given generator.
-  function stealthKeys(address registrant, address generator)
-    external
-    view
-    returns (bytes memory spendingPubKey, bytes memory viewingPubKey);
-
-  /// @notice Sets the caller's stealth public keys for the `generator` contract.
-  function registerKeys(address generator, bytes memory spendingPubKey, bytes memory viewingPubKey)
-    external;
-
-  /// @notice Sets the `registrant`s stealth public keys for the `generator` contract using their
-  /// `signature`.
-  /// @dev MUST support both EOA signatures and EIP-1271 signatures.
-  function registerKeysOnBehalf(
-    address registrant,
-    address generator,
-    bytes memory signature,
-    bytes memory spendingPubKey,
-    bytes memory viewingPubKey
-  ) external;
-
-  /// @dev Emitted when a registrant updates their registered stealth keys.
-  event StealthKeyChanged(
-    address indexed registrant, address indexed generator, bytes spendingPubKey, bytes viewingPubKey
-  );
-}
+/// @notice Generates a stealth address from a stealth meta address.
+/// @param stealthMetaAddress The recipient's stealth meta-address.
+/// @return stealthAddress The recipient's stealth address.
+/// @return ephemeralPubKey The ephemeral public key used to generate the stealth address.
+/// @return viewTag The view tag derived from the shared secret.
+function generateStealthAddress(bytes memory stealthMetaAddress)
+  external
+  view
+  returns (address stealthAddress, bytes memory ephemeralPubKey, bytes1 viewTag);
 ```
 
-### `IERC5564Generator`
+A recipient MUST be able to check if a stealth address belongs to them by calling a method with the following signature:
 
 ```solidity
-/// @notice Interface for generating stealth addresses for keys from a given stealth address scheme.
-/// @dev The Generator contract MUST have a method called `stealthKeys` that returns the recipient's
-/// public keys as the correct types. The return types will vary for each generator, so a sample
-/// is shown below.
-interface IERC5564Generator {
-  /// @notice Given a `registrant`, returns all relevant data to compute a stealth address.
-  /// @dev MUST return all zeroes if the registrant has not registered keys for this generator.
-  /// @dev The returned `viewTag` MUST be the hash of the `sharedSecret`. THe hashing function used
-  /// is specified by the generator.
-  /// @dev `ephemeralPubKey` represents the ephemeral public key used by the sender.
-  /// @dev Intended to be used off-chain only to prevent exposing secrets on-chain.
-  /// @dev Consider running this against a local node, or using an off-chain library with the same
-  /// logic, instead of via an `eth_call` to a public RPC provider to avoid leaking secrets.
-  function generateStealthAddress(address registrant)
-    external
-    view
-    returns (
-      address stealthAddress,
-      bytes memory ephemeralPubKey,
-      bytes memory sharedSecret,
-      bytes32 viewTag
-    );
-
-  /// @notice Returns the stealth public keys for the given `registrant`, in the types that best
-  /// represent the curve.
-  /// @dev The below is an example for the secp256k1 curve.
-  function stealthKeys(address registrant)
-    external
-    view
-    returns (
-      uint256 spendingPubKeyX,
-      uint256 spendingPubKeyY,
-      uint256 viewingPubKeyX,
-      uint256 viewingPubKeyY
-    );
-}
+/// @notice Returns true if funds sent to a stealth address belong to the recipient who controls
+/// the corresponding spending key.
+/// @param stealthAddress The recipient's stealth address.
+/// @param ephemeralPubKey The ephemeral public key used to generate the stealth address.
+/// @param viewingKey The recipient's viewing private key.
+/// @return True if funds sent to the stealth address belong to the recipient.
+function checkStealthAddress(
+  address stealthAddress,
+  bytes memory ephemeralPubKey,
+  bytes memory viewingKey
+) external view returns (bool);
 ```
 
-### `IERC5564Messenger`
+A recipient MUST be able to compute the private key for a stealth address by calling a method with the following signature:
 
 ```solidity
-/// @notice Interface for announcing that something was sent to a stealth address.
-interface IERC5564Messenger {
+/// @notice Computes the stealth private key for a stealth address.
+/// @param stealthAddress The expected stealth address.
+/// @param ephemeralPubKey The ephemeral public key used to generate the stealth address.
+/// @param spendingKey The recipient's spending private key.
+/// @return stealthKey The stealth private key corresponding to the stealth address.
+/// @dev The stealth address input is not strictly necessary, but it is included so the method
+/// can validate that the stealth private key was generated correctly.
+function computeStealthKey(
+  address stealthAddress,
+  bytes memory ephemeralPubKey,
+  bytes memory spendingKey
+) external view returns (bytes memory);
+```
+
+The implementation of these methods is scheme-specific. The specification of a new stealth address scheme MUST specify the implementation for each of these methods. Additionally, although these function interfaces are specified in Solidity, they do not necessarily ever need to be implemented in Solidity, but any library or SDK conforming to this specification MUST implement these methods with compatible function interfaces.
+
+A one byte integer is used to identify stealth address schemes. A mapping from the scheme ID to it's specification is maintained in **{TODO where to maintain it?}**. An EIP is required to standardize a new stealth address scheme. These EIP extensions MUST specify:
+
+- The integer identifier for the scheme.
+- The algorithm for encoding a stealth meta-address (i.e. the spending public key and viewing public key) into a `bytes` array, and decoding it from `bytes` to the native key types of that scheme.
+- The algorithm for the `generateStealthAddress` method.
+- The algorithm for the `checkStealthAddress` method.
+- The algorithm for the `computeStealthKey` method.
+
+This specification additionally defines a singleton `ERC5564Messenger` contract that emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain. The contract is specified as follows:
+
+```solidity
+/// @notice Interface for announcing when something is sent to a stealth address.
+contract IERC5564Messenger {
   /// @dev Emitted when sending something to a stealth address.
   /// @dev See the `announce` method for documentation on the parameters.
-  event Announcement(
-    bytes ephemeralPubKey, address indexed stealthAddress, bytes32 viewTag, bytes32 metadata
-  );
+  event Announcement(address indexed stealthAddress, bytes ephemeralPubKey, bytes32 metadata);
 
   /// @dev Called by integrators to emit an `Announcement` event.
-  /// @param ephemeralPubKey Ephemeral public key used by the sender.
   /// @param stealthAddress The computed stealth address for the recipient.
-  /// @param viewTag The hash of the shared secret used to compute the stealth address.
+  /// @param ephemeralPubKey Ephemeral public key used by the sender.
   /// @param metadata An arbitrary field that the sender can use however they like, but the below
   /// guidelines are recommended:
-  ///   - When sending ERC-20 tokens, the metadata SHOULD include the token address as the first 20
-  ///     bytes, and the amount being sent as the following 32 bytes.
+  ///   - The first byte of the metadata MUST be the stealth address scheme ID.
+  ///   - The second byte of the metadata MUST be the view tag.
+  ///   - When sending ERC-20 tokens, the metadata SHOULD include the token address as the next 20
+  ///     bytes, and the amount being sent in the remaining 10 bytes.
   ///   - When sending ERC-721 tokens, the metadata SHOULD include the token address as the first 20
-  ///     bytes, and the token ID being sent as the following 32 bytes.
-  function announce(
-    bytes memory ephemeralPubKey,
-    address stealthAddress,
-    bytes32 viewTag,
-    bytes32 metadata
-  ) external;
-}
-```
-
-### Sample Generator Implementation
-
-```solidity
-/// @notice Sample IERC5564Generator implementation for the secp256k1 curve.
-contract Secp256k1Generator is IERC5564Generator {
-  /// @notice Address of this chain's registry contract.
-  IERC5564Registry public constant REGISTRY = IERC5564Registry(address(0));
-
-  /// @notice Sample implementation for parsing stealth keys on the secp256k1 curve.
-  function stealthKeys(address registrant)
+  ///     bytes, and the token ID being sent as remaining 10 bytes.
+  function announce(address stealthAddress, bytes memory ephemeralPubKey, bytes32 metadata)
     external
-    view
-    returns (
-      uint256 spendingPubKeyX,
-      uint256 spendingPubKeyY,
-      uint256 viewingPubKeyX,
-      uint256 viewingPubKeyY
-    )
   {
-    // Fetch the raw spending and viewing keys from the registry.
-    (bytes memory spendingPubKey, bytes memory viewingPubKey) =
-      REGISTRY.stealthKeys(registrant, address(this));
-
-    // Parse the keys.
-    assembly {
-      spendingPubKeyX := mload(add(spendingPubKey, 0x20))
-      spendingPubKeyY := mload(add(spendingPubKey, 0x40))
-      viewingPubKeyX := mload(add(viewingPubKey, 0x20))
-      viewingPubKeyY := mload(add(viewingPubKey, 0x40))
-    }
-  }
-
-  /// @notice Sample implementation for generating stealth addresses for the secp256k1 curve.
-  function generateStealthAddress(address registrant, bytes memory ephemeralPrivKey)
-    external
-    view
-    returns (
-      address stealthAddress,
-      bytes memory ephemeralPubKey,
-      bytes memory sharedSecret,
-      bytes32 viewTag
-    )
-  {
-    // Get the ephemeral public key from the private key.
-    ephemeralPubKey = ecMul(ephemeralPrivKey, G);
-
-    // Get user's parsed public keys.
-    (
-      uint256 spendingPubKeyX,
-      uint256 spendingPubKeyY,
-      uint256 viewingPubKeyX,
-      uint256 viewingPubKeyY
-    ) = stealthKeys(registrant, address(this));
-
-    // Generate shared secret from sender's private key and recipient's viewing key.
-    sharedSecret = ecMul(ephemeralPrivKey, viewingPubKeyX, viewingPubKeyY);
-    bytes32 sharedSecretHash = keccak256(sharedSecret);
-
-    // Generate view tag for enabling faster parsing for the recipient
-    viewTag = sharedSecretHash[0:12];
-
-    // Generate a point from the hash of the shared secret
-    bytes memory sharedSecretPoint = ecMul(sharedSecret, G);
-
-    // Generate sender's public key from their ephemeral private key.
-    bytes memory stealthPubKey = ecAdd(spendingPubKeyX, spendingPubKeyY, sharedSecretPoint);
-
-    // Compute stealth address from the stealth public key.
-    stealthAddress = pubkeyToAddress(stealthPubKey);
+    emit Announcement(stealthAddress, ephemeralPubKey, metadata);
   }
 }
 ```
 
-Stealth addresses are computed using the algorithm below, assuming elliptic curves.
-Other encryption schemes such as post-quantum encryption with Kyber may need to modify this approach.
+An example stealth address scheme for elliptic curves is below. Other stealth schemes may need to modify this approach. **{TODO Modify these steps to match the three function signatures above}**
 
 - $G$ is the generator point of the curve.
 
@@ -240,7 +145,7 @@ Sending funds now works as follows:
 - The contract calls `IERC5564Messenger.announce` with $a_{stealth}$, $v$, $P_{ephemeral}$, and any metadata.
 
 To scan for funds, a recipient must retrieve all logs from the `IERC5564Messenger` contract.
-They then check if they can compute the stealth address $P_{stealth}$ that was emitted as stealth address $a_{stealth}$ in the `Announcement`. If successful, the recipient can generate  $p_{stealth}$, representing the private key that can eventually access $P_{stealth}$.
+They then check if they can compute the stealth address $P_{stealth}$ that was emitted as stealth address $a_{stealth}$ in the `Announcement`. If successful, the recipient can generate $p_{stealth}$, representing the private key that can eventually access $P_{stealth}$.
 
 The parsing process can be presented as follows:
 

--- a/eip-registry.md
+++ b/eip-registry.md
@@ -1,0 +1,108 @@
+---
+eip: TODO
+title: Stealth Meta-Address Registry
+description: A registry to map addresses to stealth meta-addresses
+author: Toni Wahrstätter (@nerolation), Matt Solomon (@mds1), Ben DiFrancesco (@apbendi), Vitalik Buterin <vitalik.buterin@ethereum.org>
+discussions-to: TODO
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-01-24
+---
+
+## Abstract
+
+This specification defines a standardized way of storing and retrieving an entity's stealth meta-address, by extending [EIP-5564](./eip-5564.md).
+
+## Motivation
+
+The standardization of non-interactive stealth address generation holds the potential to greatly enhance the privacy capabilities of Ethereum by enabling the recipient of a transfer to remain anonymous when receiving an asset. Making stealth addresses easy to use by providing a shared, standardized registry for make it even easier to non-interactively send and receive assets with stealth addresses.
+
+## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+This contract defines an `ERC5564Registry` that stores the stealth meta-address for entities. These entities may be identified by an address, ENS name, or other identifier. This MUST be a singleton contract, with one instance per chain.
+
+The contract is specified below. A one byte integer is used to identify the stealth address scheme. This integer is used to differentiate between different stealth address schemes. A mapping from the scheme ID to it's specification is maintained in **{TODO where to maintain it?}**.
+
+```solidity
+pragma solidity ^0.8.17;
+
+/// @notice Registry to map an address or other identifier to its stealth meta-address.
+contract ERC5564Registry {
+  /// @dev Emitted when a registrant updates their stealth meta-address.
+  event StealthMetaAddressSet(
+    bytes indexed registrant, uint256 indexed scheme, bytes stealthMetaAddress
+  );
+
+  /// @notice Maps a registrant's identifier to the scheme to the stealth meta-address.
+  /// @dev Registrant may be a 160 bit address or other recipient identifier, such as an ENS name.
+  /// @dev Scheme is an integer identifier for the stealth address scheme.
+  /// @dev MUST return zero if a registrant has not registered keys for the given inputs.
+  mapping(bytes => mapping(uint256 => bytes)) public stealthMetaAddressOf;
+
+  /// @notice Sets the caller's stealth meta-address for the given stealth address scheme.
+  /// @param scheme An integer identifier for the stealth address scheme.
+  /// @param stealthMetaAddress The stealth meta-address to register.
+  function registerKeys(uint256 scheme, bytes memory stealthMetaAddress) external {
+    stealthMetaAddressOf[abi.encode(msg.sender)][scheme] = stealthMetaAddress;
+  }
+
+  /// @notice Sets the `registrant`s stealth meta-address for the given scheme.
+  /// @param registrant Recipient identifier, such as an ENS name.
+  /// @param scheme An integer identifier for the stealth address scheme.
+  /// @param signature A signature from the `registrant` authorizing the registration.
+  /// @param stealthMetaAddress The stealth meta-address to register.
+  /// @dev MUST support both EOA signatures and EIP-1271 signatures.
+  /// @dev MUST revert if the signature is invalid.
+  function registerKeysOnBehalf(
+    address registrant,
+    uint256 scheme,
+    bytes memory signature,
+    bytes memory stealthMetaAddress
+  ) external {
+    // TODO If registrant has no code, spit signature into r, s, and v and call `ecrecover`.
+    // TODO If registrant has code, call `isValidSignature` on the registrant.
+  }
+
+  /// @notice Sets the `registrant`s stealth meta-address for the given scheme.
+  /// @param registrant Recipient identifier, such as an ENS name.
+  /// @param scheme An integer identifier for the stealth address scheme.
+  /// @param signature A signature from the `registrant` authorizing the registration.
+  /// @param stealthMetaAddress The stealth meta-address to register.
+  /// @dev MUST support both EOA signatures and EIP-1271 signatures.
+  /// @dev MUST revert if the signature is invalid.
+  function registerKeysOnBehalf(
+    bytes memory registrant,
+    uint256 scheme,
+    bytes memory signature,
+    bytes memory stealthMetaAddress
+  ) external {
+    // TODO How to best generically support any registrant identifier / name
+    // system without e.g. hardcoding support just for ENS?
+  }
+}
+```
+
+Deployment is done using the keyless deployment method commonly known as Nick’s method, {TODO continue describing this and include transaction data, can base it off the format/description used in EIP-1820 and EIP-2470}.
+
+## Rationale
+
+TODO
+
+## Backwards Compatibility
+
+This EIP is fully backward compatible.
+
+## Reference Implementation
+
+You can find an implementation of this standard above.
+
+## Security Considerations
+
+TODO
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
High level changes:
- Pulls registry out of core EIP and into a WIP EIP extension
- Uses "stealth meta-address" as the new terminology
- Specifies how to get a spending and viewing key from a stealth meta-address
- Specifies function interfaces for the three core actions in a stealth address scheme, where schemes are identified by 1 byte integers. Open question: where should the mapping from integer to scheme spec be defined?
- Details what information is needed to standardize a specific stealth address scheme.

Still TODO in a follow up PR:
- Above open question around where to store the scheme IDs?
- Determine if want a scheme such as `st:0x<x>}` for stealth meta address formats, where `x` is the bytes-encoded stealth meta-address for a given scheme
- Some updates in the elliptic curve example section
- Some open questions for the registry contract listed in that file