### PR TITLE
Add secp256k1 specs

### DIFF
--- a/eip-5564.md
+++ b/eip-5564.md
@@ -203,7 +203,7 @@ Parsing - Locate one's own stealth address(es):
 - The  `checkStealthAddress` function performs the following computations:
   - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
-  - The view tag $v$ is extracted by taking the most significant byte $s_{h}[0]$ and can be compared to the given view tag.
+  - The view tag $v$ is extracted by taking the most significant byte $s_{h}[0]$ and can be compared to the given view tag. If the view tags do not match, this `Announcement` is not for the user. If the view tags match, continue on.
   - Multiply the hashed shared secret with the generator point $S_h = s_h \cdot G$.
   - The stealth public key is computed as $P_{stealth} = P_{spend} + S_h$.
   - The derived stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -162,7 +162,7 @@ st:eth:0x<spendingKey><viewingKey>
 
 ### Initial Implementation of SECP256k1 with View Tags
 
-This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a stealth address scheme that utilizes the SECP256k1 elliptic curve and`view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a stealth address scheme that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
 
 The following reference is divided into a stealth address generation, parsing and stealth private key derivation section and is defined as follows:
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -164,7 +164,12 @@ st:eth:0x<spendingKey><viewingKey>
 
 This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a stealth address scheme that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
 
-The following reference is divided into a stealth address generation, parsing and stealth private key derivation section and is defined as follows:
+The following reference is divided into three sections:
+1. Stealth address generation
+2. Parsing announcements
+3. Stealth private key derivation
+
+ Definitions:
 
 - $G$ represents the generator point of the curve.
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -2,7 +2,7 @@
 eip: 5564
 title: Stealth Addresses
 description: Private, non-interactive transfers and interactions
-author: Toni Wahrstätter (@nerolation), Matt Solomon (@mds1), Ben DiFrancesco (@apbendi), Vitalik Buterin <vitalik.buterin@ethereum.org>
+author: Toni Wahrstätter (@nerolation), Matt Solomon (@mds1), Ben DiFrancesco (@apbendi), Vitalik Buterin (@vbuterin)
 discussions-to: https://ethereum-magicians.org/t/eip-5566-stealth-addresses-for-smart-contract-wallets/10614
 status: Draft
 type: Standards Track
@@ -146,13 +146,33 @@ contract IERC5564Messenger {
 }
 ```
 
-An example stealth address scheme for elliptic curves is below. Other stealth schemes may need to modify this approach. 
+
+### Stealth meta-address format
+
+The new address format for the stealth meta-addresses is based on [ERC-3770](./eip-3770.md) and extends it by adding a `st:` (*stealth*) as prefix.
+Thus, stealth meta-addresses on Ethereum come with the following format:
+
+```
+st:eth:0x<spendingKey><viewingKey>
+``` 
+
+*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, however, the prefix is sliced away before doing any computations on the stealth meta-address.*
+
+---
+
+### Initial Implementation of SECP256k1 with View Tags
+
+This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a stealth address scheme that utilizes the SECP256k1 elliptic curve and`view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+
+The following reference is divided into a stealth address generation, parsing and stealth private key derivation section and is defined as follows:
 
 - $G$ represents the generator point of the curve.
 
-- Recipient has published a stealth meta-address that constists of the public keys $P_{spend}$ and $P_{view}$.
+Generation - Generate stealth address from stealth meta-address:
 
 - Recipient has has access to the private keys $p_{spend}$, $p_{view}$ from which $P_{spend}$ and $P_{view}$ are derived.
+
+- Recipient has published a stealth meta-address that consists of the public keys $P_{spend}$ and $P_{view}$.
 
 - Sender passes the stealth meta-address to the `generateStealthAddress` function.
 
@@ -169,7 +189,7 @@ An example stealth address scheme for elliptic curves is below. Other stealth sc
   - The function returns the stealth address $a_{stealth}$, the ephemeral public key $P_{ephemeral}$ and the view tag $v$. 
 
 
-An example function to check whether a stealth address belongs to oneself:
+Parsing - Locate one's own stealth address(es):
 
 - User has access to the viewing private key $p_{view}$ and the public spending key $P_{spend}$.
 
@@ -183,7 +203,7 @@ An example function to check whether a stealth address belongs to oneself:
   - The derived stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.
   - Return `true` if the stealth address of the announcement matches the derived stealth address, else return `false`.
 
-An example function to derive the private key of a stealth address:
+Private key derivation - Generate the stealth address private key from the hashed shared secret and the spending private key.
 
 - User has access to the viewing private key, spending private key $p_{spend}$.
 
@@ -208,17 +228,6 @@ Usually, the recipient of a stealth address transaction has to perform the follo
 - 1x ecADD,
 
 The view tags approach is introduced to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 1 bytes length was is based on the maximum required space to reliably filter not matching announcement. With 1 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ is $1/256$. This means that users can almost certainly skip the above three operations for any announcements that to do not involve them. Since the view tag reveals one byte of the shared secret, the security margin is reduced from 128 bits to 124 bits. Notably, this only affects the privacy and not the secure generation of a stealth address.
-
-### Stealth meta-address format
-
-The new address format for the stealth meta-addresses is based on [ERC-3770](./eip-3770.md) and extends it by adding a `st:` (*stealth*) as prefix.
-Thus, stealth meta-addresses on Ethereum come with the following format:
-
-```
-st:eth:0x<spendingKey><viewingKey>
-``` 
-
-*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, however, the prefix is sliced away before doing any computations on the stealth meta-address.*
 
 ## Rationale
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -198,6 +198,7 @@ Parsing - Locate one's own stealth address(es):
 - The  `checkStealthAddress` function performs the following computations:
   - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
+  - The view tag $v$ is extracted by taking the most significant byte $s_{h}[0]$ and can be compared to the given view tag.
   - Multiply the hashed shared secret with the generator point $S_h = s_h \cdot G$.
   - The stealth public key is computed as $P_{stealth} = P_{spend} + S_h$.
   - The derived stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -156,7 +156,7 @@ Thus, stealth meta-addresses on Ethereum come with the following format:
 st:eth:0x<spendingKey><viewingKey>
 ``` 
 
-*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, however, the prefix is sliced away before doing any computations on the stealth meta-address.*
+*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, as the prefix is sliced away before doing any computations on the stealth meta-address.*
 
 ---
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -175,7 +175,7 @@ The following reference is divided into three sections:
 
 Generation - Generate stealth address from stealth meta-address:
 
-- Recipient has has access to the private keys $p_{spend}$, $p_{view}$ from which $P_{spend}$ and $P_{view}$ are derived.
+- Recipient has has access to the private keys $p_{spend}$, $p_{view}$ from which public keys $P_{spend}$ and $P_{view}$ are derived.
 
 - Recipient has published a stealth meta-address that consists of the public keys $P_{spend}$ and $P_{view}$.
 

--- a/eip-5564.md
+++ b/eip-5564.md
@@ -211,7 +211,7 @@ Parsing - Locate one's own stealth address(es):
 
 Private key derivation - Generate the stealth address private key from the hashed shared secret and the spending private key.
 
-- User has access to the viewing private key, spending private key $p_{spend}$.
+- User has access to the viewing private key $p_{view}$, spending private key $p_{spend}$.
 
 - User has access to a set of `Announcement` events for which the `checkStealthAddress` function returns `true`. 
 


### PR DESCRIPTION
I've move some parts to structure it such that first comes the agnostic foundation (the actual ERC), followed by the first definition of a first crypto scheme.

Let me know what you think.
I think this may work that way - we also made clear enough how one could build upon it, i guess (?).